### PR TITLE
add twitter app dev credentials

### DIFF
--- a/app/config/config.js
+++ b/app/config/config.js
@@ -1,6 +1,12 @@
 var oauth_callback = 'http://localhost:666/callback/';
-var oauth_consumer_key = 'NwA6HpLGxsDgFhUaWpvvIV8aQ';
-var oauth_consumer_secret = 'BbsF9Bqb2sUz1h7KHyTTuIGSPLlAjuZDQ8otzvoYXQSjlbo22r';
+
+//Twitter app Prod:
+//var oauth_consumer_key = 'NwA6HpLGxsDgFhUaWpvvIV8aQ';
+//var oauth_consumer_secret = 'BbsF9Bqb2sUz1h7KHyTTuIGSPLlAjuZDQ8otzvoYXQSjlbo22r';
+
+//Twitter app dev
+var oauth_consumer_key = 'acWguFLGgV5VUiNFRE6rrnaaM';
+var oauth_consumer_secret = 'Yr1QgIobfMpVIEkO4vKk3wmdgZIoRXplSlfKNVJsC9dYHD9vUB';
 
 var linkastor_url = 'http://localhost:5000';
 


### PR DESCRIPTION
We really need to do something about security, having our twitter app credentials publicly on github is a terrible thing...

I'll have a look at how buffer handles the twitter auth : https://github.com/bufferapp/buffer-chrome
